### PR TITLE
feat(redis): migrate to DigitalOcean managed Redis service

### DIFF
--- a/.claude/commands/wakeup.md
+++ b/.claude/commands/wakeup.md
@@ -1,4 +1,4 @@
-Following @claude.md guidance, access @memory/current-session.md and confirm the current focus in this session. If you are not focused on the current task or need assistance, please let me know. Once you have done this, SUGGEST the next steps for this session and ask for confirmation from the user.
+Following @claude.md guidance, access @memory/active/ folder and confirm the current focus in this session. If you are not focused on the current task or need assistance, please let me know. Once you have done this, SUGGEST the next steps for this session and ask for confirmation from the user.
 
 Always remember the rules of engagement:
 1. Always update your memory when you learn you information as Claude.md dictates

--- a/.do-app-spec-redis-service.yaml
+++ b/.do-app-spec-redis-service.yaml
@@ -1,7 +1,7 @@
-name: medical-patients-generator-redis
+name: medical-patients-generator-managed
 region: nyc
 
-# OPTIMAL SETUP: $20/month total ($5 FastAPI + $5 Redis + $10 PostgreSQL)
+# OPTIMAL SETUP: Uses DigitalOcean Managed Redis (configured separately)
 # Auto-deploy from main branch
 services:
 # FastAPI Backend
@@ -51,7 +51,8 @@ services:
   - key: DATABASE_URL
     value: ${medical_patients_db.DATABASE_URL}
   - key: REDIS_URL
-    value: "redis://redis-service:6379"  # Internal service connection
+    value: ${REDIS_URL}  # Managed Redis connection
+    type: SECRET
   - key: CACHE_ENABLED
     value: "true"
   - key: DEBUG
@@ -59,33 +60,6 @@ services:
   - key: CORS_ORIGINS
     value: "https://milmed.tech"
 
-# Redis Service (in-app container)
-- name: redis-service
-  image:
-    registry_type: DOCKER_HUB
-    repository: redis
-    tag: "7-alpine"
-  
-  # Smallest instance for Redis
-  instance_size_slug: apps-s-1vcpu-0.5gb  # $5/month
-  instance_count: 1
-  
-  # Redis configuration
-  run_command: redis-server --appendonly yes --dir /data
-  
-  # Health check for Redis
-  health_check:
-    http_path: /
-    port: 6379
-    initial_delay_seconds: 10
-    period_seconds: 30
-    timeout_seconds: 5
-    failure_threshold: 3
-    success_threshold: 1
-  
-  # Internal ports (no external access needed)
-  internal_ports:
-  - 6379
 
 # Static frontend
 static_sites:

--- a/.env.example
+++ b/.env.example
@@ -11,6 +11,10 @@ POSTGRES_PASSWORD=medgen_password
 POSTGRES_DB=medgen_db
 
 # Redis Configuration
+# For DigitalOcean Managed Redis (production):
+# REDIS_URL=rediss://default:password@redis-cluster-name.db.ondigitalocean.com:25061/0
+# Note: Use 'rediss://' (with double 's') for SSL/TLS connections
+# For local Redis (development):
 REDIS_URL=redis://redis:6379/0
 CACHE_TTL=3600
 CACHE_ENABLED=True

--- a/.env.production.example
+++ b/.env.production.example
@@ -1,0 +1,26 @@
+# Production Environment Variables Example
+
+# API Configuration
+API_KEY=${API_KEY}
+DEBUG=False
+
+# CORS Configuration  
+CORS_ORIGINS=https://milmed.tech,https://www.milmed.tech
+
+# Database Configuration (Managed PostgreSQL)
+DATABASE_URL=${db.DATABASE_URL}
+
+# Redis Configuration (Managed Redis)
+# Using DigitalOcean Managed Redis with SSL/TLS
+# Note: Use the private hostname when running within the same VPC
+# Format: rediss://username:password@hostname:port/database
+REDIS_URL=rediss://default:YOUR_REDIS_PASSWORD@private-your-redis-cluster.db.ondigitalocean.com:25061/0
+
+# Cache Configuration
+CACHE_ENABLED=True
+CACHE_TTL=3600
+
+# Application Settings
+ENVIRONMENT=production
+MAX_PATIENTS_PER_JOB=10000
+JOB_TIMEOUT_SECONDS=3600

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ This application generates simulated patient data for military medical exercises
     - Temporal metadata including casualty event IDs, mass casualty classification, and environmental conditions
 - **Multiple Output Formats**: JSON and CSV formats with compressed ZIP archives
 - **Data Security Options**: AES-256-GCM encryption with unique salts per encryption operation
-- **Dockerized Development Environment**: Complete Docker Compose setup with PostgreSQL and Redis support
+- **Dockerized Development Environment**: Complete Docker Compose setup with PostgreSQL and Redis support (optional managed Redis for production)
 - **Database Schema Management**: Alembic migrations for robust schema versioning
 - **Background Job Processing**: Async patient generation with real-time progress tracking and job management
 
@@ -289,9 +289,26 @@ docker run -d \
 - `API_KEY`: Primary API authentication key
 - `SECRET_KEY`: Application secret for session management
 - `REDIS_URL`: Redis connection (optional, for caching)
+  - Development: `redis://localhost:6379/0`
+  - Production (managed): `rediss://default:password@cluster.db.ondigitalocean.com:25061/0`
 - `ENVIRONMENT`: Set to "production" for production deployments
 
 For advanced deployment configurations, refer to the docker-compose files in the repository.
+
+### Redis Configuration
+
+The application supports both self-hosted and managed Redis services:
+
+**Development (Docker Compose)**:
+- Uses local Redis container
+- No additional configuration needed
+- Automatically started with `task dev`
+
+**Production (Managed Redis)**:
+- Supports DigitalOcean Managed Redis or similar services
+- Use `rediss://` protocol for SSL/TLS connections
+- Configure via `REDIS_URL` environment variable
+- See `docs/redis-migration.md` for migration guide
 
 ### Testing
 

--- a/docker-compose.staging.yml
+++ b/docker-compose.staging.yml
@@ -16,8 +16,8 @@ services:
       - HOST=0.0.0.0
       # Staging database in managed PostgreSQL cluster
       - DATABASE_URL=postgresql://staging_user:${STAGING_DB_PASSWORD}@app-7a761f5d-a598-4efc-9f1a-cd756365d498-do-user-323970-0.m.db.ondigitalocean.com:25060/medgen_staging?sslmode=require
-      # Use Redis database 1 for staging (0 is for production)
-      - REDIS_URL=redis://medical-patients_redis_1:6379/1
+      # Use managed Redis for staging (different database number)
+      - REDIS_URL=${STAGING_REDIS_URL:-redis://medical-patients_redis_1:6379/1}
       - API_KEY=${STAGING_API_KEY:-staging_secret_key_here}
       - SECRET_KEY=${STAGING_SECRET_KEY:-staging_secret}
       - DEBUG=${DEBUG:-False}

--- a/docs/redis-migration.md
+++ b/docs/redis-migration.md
@@ -1,0 +1,149 @@
+# Redis Migration Guide: Custom to Managed Redis
+
+## Overview
+This guide documents the migration from a custom Redis container to DigitalOcean Managed Redis service.
+
+## Benefits of Managed Redis
+- **High Availability**: Automatic failover and redundancy
+- **Managed Backups**: Automated daily backups with point-in-time recovery
+- **Security**: SSL/TLS encryption, private networking
+- **Monitoring**: Built-in metrics and alerts
+- **Zero Maintenance**: No need to manage Redis versions or patches
+
+## Configuration Changes
+
+### 1. Environment Variables
+Update your production environment variables:
+
+```bash
+# Old configuration (custom Redis container)
+REDIS_URL=redis://redis:6379
+
+# New configuration (managed Redis)
+REDIS_URL=rediss://default:<password>@<cluster-name>.db.ondigitalocean.com:25061/0
+```
+
+**Important**: Note the `rediss://` protocol (with double 's') for SSL/TLS connections.
+
+### 2. Application Files Updated
+- `.env.example` - Added managed Redis documentation
+- `production-app-spec.yaml` - Removed Redis service, using environment variable
+- `docker-compose.staging.yml` - Added support for managed Redis URL
+- `.do-app-spec-redis-service.yaml` - Removed Redis service definition
+
+### 3. DigitalOcean Setup
+
+#### Create Managed Redis Database
+1. Go to DigitalOcean Control Panel > Databases
+2. Click "Create Database"
+3. Choose Redis
+4. Select configuration:
+   - **Engine**: Redis 7
+   - **Plan**: Basic ($15/month for 1GB RAM)
+   - **Region**: Same as your app (e.g., NYC3)
+   - **VPC**: Same VPC as your app
+
+#### Configure Connection
+1. In the database overview, go to "Connection Details"
+2. Copy the connection string (use "Connection string" format)
+3. Add to your app's environment variables:
+   ```bash
+   doctl apps update <app-id> --spec production-app-spec.yaml
+   doctl apps config set <app-id> REDIS_URL=<connection-string>
+   ```
+
+#### Security Settings
+1. Add your app to the trusted sources:
+   - Go to Settings > Trusted Sources
+   - Add your app's name
+2. Enable eviction policy:
+   - Go to Settings > Eviction Policy
+   - Select "allkeys-lru" for cache behavior
+
+## Migration Steps
+
+### 1. Pre-Migration
+- [ ] Create managed Redis database in DigitalOcean
+- [ ] Test connection from local environment
+- [ ] Update staging environment first
+
+### 2. Migration
+1. Update app environment variable:
+   ```bash
+   doctl apps config set <app-id> REDIS_URL=<managed-redis-url>
+   ```
+
+2. Deploy the updated app spec:
+   ```bash
+   doctl apps update <app-id> --spec production-app-spec.yaml
+   ```
+
+3. Monitor app logs for successful Redis connection:
+   ```bash
+   doctl apps logs <app-id> --follow
+   ```
+
+### 3. Post-Migration
+- [ ] Verify cache operations are working
+- [ ] Check application performance
+- [ ] Remove old Redis container from billing
+
+## Testing Connection
+
+### Local Testing
+```python
+import redis
+import ssl
+
+# Create SSL context for managed Redis
+ssl_context = ssl.create_default_context()
+ssl_context.check_hostname = False
+
+# Connect to managed Redis
+r = redis.Redis.from_url(
+    "rediss://default:password@cluster.db.ondigitalocean.com:25061/0",
+    ssl_cert_reqs="required",
+    ssl_ca_certs=None,
+    ssl_context=ssl_context
+)
+
+# Test connection
+print(r.ping())  # Should return True
+```
+
+### Application Testing
+The application will automatically handle SSL connections when using `rediss://` URLs.
+
+## Rollback Plan
+If issues occur, revert to custom Redis:
+1. Update REDIS_URL back to `redis://redis:6379`
+2. Redeploy with the old app spec that includes Redis service
+
+## Cost Comparison
+- **Custom Redis Container**: $5/month (0.5GB RAM)
+- **Managed Redis Basic**: $15/month (1GB RAM)
+- **Additional Benefits**: Backups, monitoring, high availability
+
+## Monitoring
+After migration, monitor:
+- Redis connection pool health at `/api/v1/health`
+- Cache hit rates in application metrics
+- Redis memory usage in DO dashboard
+- Connection count and latency
+
+## Troubleshooting
+
+### SSL Connection Errors
+If you see SSL errors, ensure:
+- Using `rediss://` protocol (not `redis://`)
+- Redis client library supports SSL (redis-py >= 4.0)
+
+### Connection Timeouts
+- Check trusted sources configuration
+- Verify VPC settings match between app and database
+- Test connectivity from app container
+
+### Performance Issues
+- Monitor latency between app and Redis
+- Consider upgrading to a larger Redis plan if needed
+- Check eviction policy settings

--- a/docs/redis-migration.md
+++ b/docs/redis-migration.md
@@ -45,11 +45,17 @@ REDIS_URL=rediss://default:<password>@<cluster-name>.db.ondigitalocean.com:25061
 
 #### Configure Connection
 1. In the database overview, go to "Connection Details"
-2. Copy the connection string (use "Connection string" format)
-3. Add to your app's environment variables:
+2. Choose the appropriate connection method:
+   - **Private Network (Recommended)**: Use the VPC network connection string
+   - **Public Network**: Use the public connection string (if trusted sources configured)
+3. Connection format:
+   ```
+   rediss://default:<password>@<hostname>:25061/0
+   ```
+4. Add to your app's environment variables:
    ```bash
    doctl apps update <app-id> --spec production-app-spec.yaml
-   doctl apps config set <app-id> REDIS_URL=<connection-string>
+   doctl apps config set <app-id> REDIS_URL="rediss://default:<password>@<hostname>:25061/0"
    ```
 
 #### Security Settings
@@ -139,11 +145,18 @@ If you see SSL errors, ensure:
 - Redis client library supports SSL (redis-py >= 4.0)
 
 ### Connection Timeouts
-- Check trusted sources configuration
-- Verify VPC settings match between app and database
-- Test connectivity from app container
+- **Private Network**: Ensure app and Redis are in the same VPC
+- **Public Network**: Add your IP/app to trusted sources
+- The private hostname (e.g., `private-*.db.ondigitalocean.com`) is only accessible within the VPC
+- Test connectivity from within the app container, not from local machine
 
 ### Performance Issues
 - Monitor latency between app and Redis
 - Consider upgrading to a larger Redis plan if needed
 - Check eviction policy settings
+
+### Testing from Local Development
+To test the managed Redis from your local machine:
+1. Use the public hostname (not the private one)
+2. Add your IP address to the trusted sources in the Redis settings
+3. Or use an SSH tunnel through your DigitalOcean droplet

--- a/production-app-spec.yaml
+++ b/production-app-spec.yaml
@@ -34,8 +34,9 @@ services:
         value: ${db.DATABASE_URL}
         scope: RUN_AND_BUILD_TIME
       - key: REDIS_URL
-        value: redis://redis:6379
+        value: ${REDIS_URL}
         scope: RUN_AND_BUILD_TIME
+        type: SECRET
       - key: CACHE_ENABLED
         value: "true"
         scope: RUN_AND_BUILD_TIME
@@ -50,17 +51,6 @@ services:
         scope: RUN_AND_BUILD_TIME
         type: SECRET
 
-  - name: redis
-    image:
-      registry_type: DOCKER_HUB
-      registry: library
-      repository: redis
-      tag: 7-alpine
-    run_command: redis-server --appendonly yes --dir /data
-    instance_size_slug: apps-s-1vcpu-0.5gb
-    instance_count: 1
-    internal_ports:
-      - 6379
 
 static_sites:
   - name: frontend

--- a/production-fix-app-spec.yaml
+++ b/production-fix-app-spec.yaml
@@ -31,8 +31,9 @@ services:
         value: ${medical-patients-db.DATABASE_URL}
         scope: RUN_AND_BUILD_TIME
       - key: REDIS_URL
-        value: redis://redis-service:6379
+        value: ${REDIS_URL}
         scope: RUN_AND_BUILD_TIME
+        type: SECRET
       - key: CACHE_ENABLED
         value: "true"
         scope: RUN_AND_BUILD_TIME
@@ -47,17 +48,6 @@ services:
         scope: RUN_AND_BUILD_TIME
         type: SECRET
 
-  - name: redis-service
-    image:
-      registry_type: DOCKER_HUB
-      registry: library
-      repository: redis
-      tag: 7-alpine
-    run_command: redis-server --appendonly yes --dir /data
-    instance_size_slug: apps-s-1vcpu-0.5gb
-    instance_count: 1
-    internal_ports:
-      - 6379
 
 static_sites:
   - name: frontend

--- a/scripts/test_redis_connection.py
+++ b/scripts/test_redis_connection.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""Test Redis connection with both regular and SSL connections."""
+
+import asyncio
+import os
+import sys
+from urllib.parse import urlparse
+
+import redis.asyncio as redis
+from redis.exceptions import RedisError
+
+
+async def test_redis_connection(redis_url: str) -> bool:
+    """Test Redis connection and basic operations."""
+    print(f"\nTesting Redis connection: {redis_url}")
+    
+    # Parse URL to check if SSL is needed
+    parsed = urlparse(redis_url)
+    is_ssl = parsed.scheme == "rediss"
+    
+    try:
+        # Create connection pool with appropriate SSL settings
+        if is_ssl:
+            pool = redis.ConnectionPool.from_url(
+                redis_url,
+                decode_responses=True,
+                max_connections=10,
+                ssl_cert_reqs="required"
+            )
+        else:
+            pool = redis.ConnectionPool.from_url(
+                redis_url,
+                decode_responses=True,
+                max_connections=10
+            )
+        
+        # Create client
+        client = redis.Redis(connection_pool=pool)
+        
+        # Test basic operations
+        print("1. Testing PING...")
+        pong = await client.ping()
+        print(f"   ✓ PING successful: {pong}")
+        
+        print("2. Testing SET/GET...")
+        test_key = "test:connection"
+        test_value = "Hello from Medical Patients Generator"
+        
+        await client.set(test_key, test_value, ex=60)  # 60 second expiry
+        retrieved = await client.get(test_key)
+        print(f"   ✓ SET/GET successful: {retrieved}")
+        
+        print("3. Testing DELETE...")
+        deleted = await client.delete(test_key)
+        print(f"   ✓ DELETE successful: {deleted} key(s) deleted")
+        
+        print("4. Getting server info...")
+        info = await client.info("server")
+        print(f"   ✓ Redis version: {info.get('redis_version', 'Unknown')}")
+        print(f"   ✓ Mode: {info.get('redis_mode', 'Unknown')}")
+        
+        # Cleanup
+        await client.close()
+        await pool.disconnect()
+        
+        print("\n✅ Redis connection test PASSED!")
+        return True
+        
+    except RedisError as e:
+        print(f"\n❌ Redis connection test FAILED: {e}")
+        return False
+    except Exception as e:
+        print(f"\n❌ Unexpected error: {e}")
+        return False
+
+
+async def main():
+    """Main test function."""
+    # Get Redis URL from environment or use default
+    redis_url = os.getenv("REDIS_URL", "redis://localhost:6379/0")
+    
+    print("Redis Connection Test")
+    print("=" * 50)
+    
+    success = await test_redis_connection(redis_url)
+    
+    if not success:
+        print("\nTroubleshooting tips:")
+        print("1. Check if Redis is running (local) or accessible (managed)")
+        print("2. Verify the REDIS_URL environment variable")
+        print("3. For managed Redis, ensure your IP is in trusted sources")
+        print("4. For SSL connections, use 'rediss://' protocol")
+        sys.exit(1)
+    
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
## Summary
- Migrated from custom Redis container to DigitalOcean Managed Redis service
- Updated all production configurations to use environment variable for Redis URL
- Added comprehensive migration documentation and testing tools

## Changes
- **Production App Specs**: Removed Redis service container, now uses `${REDIS_URL}` environment variable
- **Documentation**: Added `docs/redis-migration.md` with step-by-step migration guide
- **Testing**: Created `scripts/test_redis_connection.py` for verifying SSL/TLS connections
- **Configuration**: Updated `.env.example` and created `.env.production.example`

## Benefits
- **High Availability**: Automatic failover and redundancy
- **Managed Backups**: Daily backups with point-in-time recovery
- **Security**: SSL/TLS encryption, VPC private networking
- **Zero Maintenance**: No need to manage Redis versions or patches

## Deployment Steps
1. Set `REDIS_URL` environment variable in DigitalOcean App Platform
2. Deploy with updated app spec
3. Monitor logs for successful connection
4. Remove old Redis container after verification

## Test plan
- [x] Local Redis tests pass
- [x] Cache service tests pass
- [ ] Deploy to production
- [ ] Verify Redis connectivity in production logs
- [ ] Test cache operations work correctly
- [ ] Monitor performance metrics

🤖 Generated with [Claude Code](https://claude.ai/code)