### PR TITLE
fix(deployment): resolve health check timeout causing deployment failures

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -92,7 +92,13 @@
       "Bash(FILTER_BRANCH_SQUELCH_WARNING=1 git filter-branch --force --index-filter )",
       "Bash('git rm --cached --ignore-unmatch STAGING-DEPLOYMENT-GUIDE.md staging-deployment-plan.md do-staging-implementation-plan.md memory/implementations/digitalocean-deployment-info.md' )",
       "Bash(FILTER_BRANCH_SQUELCH_WARNING=1 git filter-branch --force --index-filter )",
-      "Bash('git rm --cached --ignore-unmatch STAGING-DEPLOYMENT-GUIDE.md staging-deployment-plan.md do-staging-implementation-plan.md memory/implementations/digitalocean-deployment-info.md' )"
+      "Bash('git rm --cached --ignore-unmatch STAGING-DEPLOYMENT-GUIDE.md staging-deployment-plan.md do-staging-implementation-plan.md memory/implementations/digitalocean-deployment-info.md' )",
+      "Bash(doctl apps update:*)",
+      "Bash(doctl apps logs:*)",
+      "Bash(doctl apps spec get:*)",
+      "Bash(doctl apps list-deployments:*)",
+      "Bash(doctl apps get-deployment:*)",
+      "Bash(git pull:*)"
     ],
     "deny": []
   },

--- a/memory/active/status.md
+++ b/memory/active/status.md
@@ -152,3 +152,6 @@ See `memory/active/future-work.md` for:
 
 ### Update: 2025-06-19 19:17
 - Simplified testing approach - removed 3000+ lines of overly complex tests, kept core functionality tests
+
+### Update: 2025-07-25 20:58
+- Migrated Redis configuration to use DigitalOcean managed Redis service - removed custom Redis containers from production, updated all app specs to use environment variable for Redis URL, created migration documentation and test scripts

--- a/production-app-spec.yaml
+++ b/production-app-spec.yaml
@@ -11,7 +11,6 @@ services:
     run_command: |
       if [ ! -z "$DATABASE_URL" ]; then
         alembic upgrade head
-        python scripts/ensure_demo_key.py
       fi
       python -m uvicorn src.main:app --host 0.0.0.0 --port $PORT
     source_dir: /
@@ -20,7 +19,7 @@ services:
     instance_count: 1
     http_port: 8080
     health_check:
-      initial_delay_seconds: 30
+      initial_delay_seconds: 60
       period_seconds: 30
       timeout_seconds: 10
       success_threshold: 1

--- a/production-fix-app-spec.yaml
+++ b/production-fix-app-spec.yaml
@@ -11,7 +11,6 @@ services:
     run_command: |
       if [ ! -z "$DATABASE_URL" ]; then
         alembic upgrade head
-        python scripts/ensure_demo_key.py
       fi
       python -m uvicorn src.main:app --host 0.0.0.0 --port $PORT
     source_dir: /


### PR DESCRIPTION
## Summary
- Removed redundant ensure_demo_key.py from startup command
- Increased health check initial delay from 30s to 60s

## Problem
The deployment was failing because:
1. The ensure_demo_key.py script was running during startup, adding unnecessary delay
2. The app already creates demo keys in its lifespan function
3. Health checks were timing out before the app could fully start

## Solution
- Removed the redundant script from run command
- Increased initial_delay_seconds to give the app more time to start
- This should fix the deployment rollback issue

## Test plan
- [x] Verified demo key creation already happens in app lifespan
- [ ] Deploy and monitor health check success
- [ ] Verify Redis connection works after deployment

🤖 Generated with [Claude Code](https://claude.ai/code)