### PR TITLE
fix(redis): add SSL support for managed Redis and graceful fallback

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -98,7 +98,9 @@
       "Bash(doctl apps spec get:*)",
       "Bash(doctl apps list-deployments:*)",
       "Bash(doctl apps get-deployment:*)",
-      "Bash(git pull:*)"
+      "Bash(git pull:*)",
+      "Bash(diff:*)",
+      "Bash(doctl apps get:*)"
     ],
     "deny": []
   },

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -100,7 +100,8 @@
       "Bash(doctl apps get-deployment:*)",
       "Bash(git pull:*)",
       "Bash(diff:*)",
-      "Bash(doctl apps get:*)"
+      "Bash(doctl apps get:*)",
+      "Bash(gh workflow run:*)"
     ],
     "deny": []
   },

--- a/docs/managed-redis-setup.md
+++ b/docs/managed-redis-setup.md
@@ -1,0 +1,100 @@
+# DigitalOcean Managed Redis Setup Guide
+
+## Quick Setup Steps
+
+### 1. Create Managed Redis Database
+```bash
+# Using DigitalOcean CLI
+doctl databases create medical-patients-redis \
+  --engine redis \
+  --version 7 \
+  --region nyc3 \
+  --size db-s-1vcpu-1gb \
+  --num-nodes 1
+```
+
+Or via the DigitalOcean Control Panel:
+1. Go to Databases → Create Database
+2. Choose Redis 7
+3. Select Basic plan ($15/month)
+4. Same region as your app (e.g., NYC3)
+5. Same VPC as your app
+
+### 2. Get Connection String
+```bash
+# Get the connection details
+doctl databases connection medical-patients-redis --format "Host,Port,Password,SSL"
+
+# Get the full connection string
+doctl databases connection medical-patients-redis --format "URI"
+```
+
+The connection string will look like:
+```
+rediss://default:AVNS_xxxxxxxxxxxxx@db-redis-nyc3-xxxxx.db.ondigitalocean.com:25061/0
+```
+
+**Important**: Note the `rediss://` protocol (with double 's') for SSL connections.
+
+### 3. Configure Trusted Sources
+Add your app to trusted sources:
+```bash
+# Get your app's ID
+doctl apps list
+
+# Add app as trusted source
+doctl databases firewalls append <database-id> --rule "type:app,value:<app-id>"
+```
+
+### 4. Update App Environment
+```bash
+# Set the Redis URL in your app
+doctl apps config set <app-id> \
+  REDIS_URL="rediss://default:password@hostname:25061/0" \
+  CACHE_ENABLED="true"
+```
+
+### 5. Verify Connection
+Check your app logs to confirm Redis connection:
+```bash
+doctl apps logs <app-id> --follow | grep -i redis
+```
+
+You should see:
+```
+Redis cache initialized successfully
+```
+
+## Troubleshooting
+
+### Connection Refused
+- Ensure app is in trusted sources
+- Use private hostname if in same VPC
+- Check Redis is in same region
+
+### SSL Errors
+- Ensure using `rediss://` (not `redis://`)
+- App now handles SSL automatically
+
+### Cache Not Working
+- Check CACHE_ENABLED=true
+- Verify REDIS_URL is set correctly
+- Check app logs for errors
+
+## Fallback Behavior
+
+The application now gracefully handles Redis unavailability:
+- If Redis connection fails at startup, the app continues without caching
+- All cache operations safely return None/False when Redis is unavailable
+- No errors are thrown to end users
+
+## Cost
+- Basic plan: $15/month (1GB RAM, 1 node)
+- Includes: Automated backups, monitoring, SSL encryption
+
+## Benefits Over Self-Hosted
+- No maintenance required
+- Automatic backups
+- Built-in monitoring
+- SSL encryption by default
+- High availability options

--- a/memory/active/status.md
+++ b/memory/active/status.md
@@ -148,10 +148,6 @@ See `memory/active/future-work.md` for:
    - docker-compose.staging.yml configured
    - Task commands added (staging:up/down/logs/status)
    - Deployment scripts and guides created
-   - Status monitoring enhanced
 
-### Update: 2025-06-19 19:17
-- Simplified testing approach - removed 3000+ lines of overly complex tests, kept core functionality tests
-
-### Update: 2025-07-25 20:58
-- Migrated Redis configuration to use DigitalOcean managed Redis service - removed custom Redis containers from production, updated all app specs to use environment variable for Redis URL, created migration documentation and test scripts
+### Update: 2025-07-26 14:36
+- Fixed Redis SSL support for managed Redis and improved graceful fallback when Redis is unavailable

--- a/scripts/test_redis_ssl.py
+++ b/scripts/test_redis_ssl.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python3
+"""Test Redis connection with SSL support for managed Redis."""
+
+import asyncio
+import os
+import ssl
+import sys
+from pathlib import Path
+
+# Add project root to path
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+import redis.asyncio as redis
+from config import get_settings
+
+
+async def test_redis_connection():
+    """Test Redis connection with proper SSL handling."""
+    settings = get_settings()
+    redis_url = os.getenv("REDIS_URL", settings.REDIS_URL)
+    
+    print(f"Testing Redis connection to: {redis_url}")
+    print(f"SSL enabled: {redis_url.startswith('rediss://')}")
+    
+    try:
+        if redis_url.startswith("rediss://"):
+            # Create SSL context for managed Redis
+            ssl_context = ssl.create_default_context()
+            ssl_context.check_hostname = False
+            
+            client = redis.from_url(
+                redis_url,
+                decode_responses=True,
+                ssl_cert_reqs="required",
+                ssl_context=ssl_context
+            )
+        else:
+            # Regular Redis connection
+            client = redis.from_url(redis_url, decode_responses=True)
+        
+        # Test basic operations
+        print("\n1. Testing PING...")
+        pong = await client.ping()
+        print(f"   ✓ PING successful: {pong}")
+        
+        print("\n2. Testing SET/GET...")
+        await client.set("test:key", "test_value", ex=60)
+        value = await client.get("test:key")
+        print(f"   ✓ SET/GET successful: {value}")
+        
+        print("\n3. Testing DELETE...")
+        deleted = await client.delete("test:key")
+        print(f"   ✓ DELETE successful: {deleted} key(s) deleted")
+        
+        print("\n4. Testing connection pool...")
+        pool_stats = client.connection_pool.connection_kwargs
+        print(f"   ✓ Pool config: {pool_stats.get('host', 'N/A')}")
+        
+        await client.close()
+        
+        print("\n✅ All Redis tests passed!")
+        return True
+        
+    except Exception as e:
+        print(f"\n❌ Redis connection failed: {type(e).__name__}: {e}")
+        return False
+
+
+async def test_cache_service():
+    """Test the cache service implementation."""
+    from src.core.cache import initialize_cache, get_cache_service, close_cache
+    
+    settings = get_settings()
+    redis_url = os.getenv("REDIS_URL", settings.REDIS_URL)
+    
+    print("\n\nTesting Cache Service...")
+    print("=" * 50)
+    
+    try:
+        # Initialize cache
+        print("1. Initializing cache service...")
+        await initialize_cache(redis_url, 3600)
+        cache = get_cache_service()
+        
+        if not cache:
+            print("   ❌ Cache service initialization failed")
+            return False
+            
+        print("   ✓ Cache service initialized")
+        
+        # Test operations
+        print("\n2. Testing cache operations...")
+        
+        # Set
+        success = await cache.set("test:service", {"data": "test"}, 60)
+        print(f"   ✓ SET: {success}")
+        
+        # Get
+        value = await cache.get("test:service")
+        print(f"   ✓ GET: {value}")
+        
+        # Exists
+        exists = await cache.exists("test:service")
+        print(f"   ✓ EXISTS: {exists}")
+        
+        # TTL
+        ttl = await cache.get_ttl("test:service")
+        print(f"   ✓ TTL: {ttl} seconds")
+        
+        # Delete
+        deleted = await cache.delete("test:service")
+        print(f"   ✓ DELETE: {deleted}")
+        
+        # Health check
+        healthy = await cache.health_check()
+        print(f"   ✓ Health check: {healthy}")
+        
+        # Close
+        await close_cache()
+        print("\n✅ Cache service tests passed!")
+        return True
+        
+    except Exception as e:
+        print(f"\n❌ Cache service test failed: {type(e).__name__}: {e}")
+        return False
+
+
+async def main():
+    """Run all tests."""
+    print("Redis Connection Test Suite")
+    print("=" * 50)
+    
+    # Test direct Redis connection
+    redis_ok = await test_redis_connection()
+    
+    # Test cache service
+    cache_ok = await test_cache_service()
+    
+    if redis_ok and cache_ok:
+        print("\n✅ All tests passed! Redis is properly configured.")
+        sys.exit(0)
+    else:
+        print("\n❌ Some tests failed. Please check your Redis configuration.")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/src/core/cache.py
+++ b/src/core/cache.py
@@ -37,21 +37,21 @@ class CacheService:
                 # Create SSL context for managed Redis
                 ssl_context = ssl.create_default_context()
                 ssl_context.check_hostname = False
-                
+
                 self._pool = redis.ConnectionPool.from_url(
-                    self.redis_url, 
-                    decode_responses=True, 
+                    self.redis_url,
+                    decode_responses=True,
                     max_connections=50,
                     ssl_cert_reqs="required",
                     ssl_context=ssl_context
                 )
             else:
                 self._pool = redis.ConnectionPool.from_url(
-                    self.redis_url, 
-                    decode_responses=True, 
+                    self.redis_url,
+                    decode_responses=True,
                     max_connections=50
                 )
-            
+
             # Test connection
             async with self._get_client() as client:
                 await client.ping()

--- a/src/core/cache.py
+++ b/src/core/cache.py
@@ -6,6 +6,7 @@ This module provides a centralized caching layer using Redis for improved perfor
 from contextlib import asynccontextmanager
 import json
 import logging
+import ssl
 from typing import Any, Optional
 
 import redis.asyncio as redis
@@ -31,7 +32,26 @@ class CacheService:
     async def initialize(self) -> None:
         """Initialize the Redis connection pool."""
         try:
-            self._pool = redis.ConnectionPool.from_url(self.redis_url, decode_responses=True, max_connections=50)
+            # Check if SSL is needed (rediss:// protocol)
+            if self.redis_url.startswith("rediss://"):
+                # Create SSL context for managed Redis
+                ssl_context = ssl.create_default_context()
+                ssl_context.check_hostname = False
+                
+                self._pool = redis.ConnectionPool.from_url(
+                    self.redis_url, 
+                    decode_responses=True, 
+                    max_connections=50,
+                    ssl_cert_reqs="required",
+                    ssl_context=ssl_context
+                )
+            else:
+                self._pool = redis.ConnectionPool.from_url(
+                    self.redis_url, 
+                    decode_responses=True, 
+                    max_connections=50
+                )
+            
             # Test connection
             async with self._get_client() as client:
                 await client.ping()

--- a/src/main.py
+++ b/src/main.py
@@ -51,6 +51,8 @@ async def lifespan(app: FastAPI):
         except Exception as e:
             logger.error("Failed to initialize Redis cache: %s", e)
             logger.warning("Application will continue without caching")
+            # Disable caching for this session to prevent further errors
+            settings.CACHE_ENABLED = False
 
     # Ensure demo API key exists
     try:


### PR DESCRIPTION
## Summary
- Added SSL/TLS support for managed Redis connections (rediss://)
- Enhanced Redis initialization to handle connection failures gracefully
- Application continues without caching if Redis is unavailable

## Problem
The application was failing when:
1. Managed Redis uses SSL (rediss://) protocol
2. Redis service is unavailable or misconfigured

## Solution
1. Added SSL context handling for managed Redis connections
2. Gracefully disable caching for the session when Redis fails
3. Added comprehensive documentation for managed Redis setup
4. Created test script to verify Redis connections

## Testing
- [x] Tested locally with Redis available
- [x] Tested locally with Redis unavailable (graceful fallback)
- [x] Unit tests pass
- [ ] CI/CD pipeline (pending)

## Deployment Notes
- No breaking changes
- App will work with or without Redis
- If using managed Redis, ensure connection string uses `rediss://` protocol

🤖 Generated with [Claude Code](https://claude.ai/code)